### PR TITLE
fgci-centos7-generic: Adding magma to the build.

### DIFF
--- a/configs/fgci-centos7-generic/spack/build_config.yaml
+++ b/configs/fgci-centos7-generic/spack/build_config.yaml
@@ -24,6 +24,20 @@ compilers:
       platform: linux
       os: centos7
       arch: x86_64
+  - name: 'gcc'
+    version: 6.5.0
+    variants:
+      - '+piclibs'
+    dependencies:
+      - '%gcc@4.8.5'
+    flags:
+      cflags: -O2 -g -march=westmere -ftree-vectorize
+      cxxflags: -O2 -g -march=westmere -ftree-vectorize
+      fflags: -O2 -g -march=westmere -ftree-vectorize
+    target_architecture:
+      platform: linux
+      os: centos7
+      arch: x86_64
   - name: 'intel-parallel-studio'
     version: 'cluster.2019.3'
     licenses:
@@ -99,6 +113,13 @@ packages:
       - '+metis'
   - name: 'openmpi'
     version: 3.1.4
+  - name: 'magma'
+    version: 2.5.3
+    dependencies:
+      - '%gcc@6.5.0'
+      - '^cmake%gcc@9.2.0'
+      - '^cuda%gcc@9.2.0'
+      - '^openblas%gcc@9.2.0'
   - name: 'python'
     version: 3.7.4
   - name: 'r'


### PR DESCRIPTION
This PR adds magma@2.5.3 to the build.

As cuda@10.1 does not support gcc@9.2.0, a new compiler gcc@6.5.0 was also added. Other dependencies were explicitly mentioned to avoid creating duplicate packages.