### PR TITLE
anaconda sync: triton dev -> aalto dev

### DIFF
--- a/configs/aalto-ubuntu1804-dev/anaconda/build_config.yaml
+++ b/configs/aalto-ubuntu1804-dev/anaconda/build_config.yaml
@@ -63,16 +63,17 @@ collections:
   triton-generic:
     pip_packages:
       - bash-kernel
-      - docopt
+      - jupyterlab-git
       - matlab-kernel
-      - mne
-      - numpy
+      - nbscript
+      - nbval
+      - nbzip
+      - opencv-contrib-python
       - pymanopt
       - pymvpa2
       - python-igraph
       - roboschool
-      - sphinx
-      - sphinx-rtd-theme
+
     conda_packages:
       - anaconda
       - anaconda-client
@@ -97,6 +98,7 @@ collections:
       - conda
       - conda-env
       - conda-tree
+      - configargparse
       - contextlib2
       - coverage
       - cplex
@@ -108,9 +110,11 @@ collections:
       - cython
       - dill
       - distributed
+      - docopt
       - docutils
       - fastcache
       - fastparquet
+      - feather-format
       - gmpy2
       - gpy
       - gurobi
@@ -119,6 +123,7 @@ collections:
       - hdf5
       - heapdict
       - html5lib
+      - importnb
       - ipdb
       - ipykernel
       - ipyparallel
@@ -126,8 +131,10 @@ collections:
       - ipywidgets
       - joblib
       - jupyter
+      - jupyter_contrib_nbextensions
       - jupyterlab
       - jupyterlab_server
+      - jupytext
       - keras
       - keyring
       - llvmlite
@@ -139,6 +146,7 @@ collections:
       - mkl-service
       - mkl_fft
       - mkl_random
+      - mne
       - mock
       - more-itertools
       - mosek
@@ -146,6 +154,9 @@ collections:
       - mpich2
       - navigator-updater
       - nbconvert
+      - nbdime
+      - nbstripout
+      - nbval
       - nccl
       - networkx
       - nitime
@@ -153,6 +164,7 @@ collections:
       - nose
       - numba
       - numexpr
+      - numpy
       - numpydoc
       - olefile
       - openmp
@@ -206,7 +218,9 @@ collections:
       - singledispatch
       - six
       - sortedcollections
+      - sphinx
       - sphinxcontrib
+      - sphinx_rtd_theme
       - spyder
       - sqlalchemy
       - sqlite

--- a/configs/fgci-centos7-dev/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-dev/anaconda/build_config.yaml
@@ -67,11 +67,13 @@ collections:
       - jupyterlab-git
       - matlab-kernel
       - nbscript
+      - nbval
       - nbzip
       - opencv-contrib-python
       - pymanopt
       - python-igraph
       - roboschool
+
     conda_packages:
       - anaconda
       - anaconda-client


### PR DESCRIPTION
- Should be only rearrangements to match and non-semantic changes.

- Only possibly questionable action I can notice is `mne` switches
  from pip to conda.  @eglerean