### PR TITLE
anaconda sync: triton dev -> aalto dev

### DIFF
--- a/.github/workflows/tabcheck.yaml
+++ b/.github/workflows/tabcheck.yaml
@@ -1,0 +1,19 @@
+name: Check yaml
+on: [push]
+
+jobs:
+  yamlcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install pyyaml
+      - name: check yaml
+        run: |
+          ! git grep $'\t' '**.yaml'

--- a/.github/workflows/yamlcheck.yaml
+++ b/.github/workflows/yamlcheck.yaml
@@ -1,0 +1,21 @@
+name: Check yaml
+on: [push]
+
+jobs:
+  yamlcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install pyyaml
+      - name: check yaml
+        # Apparently, if you do this using "find -exec" in one
+        # command, it does not exit with a failure status.
+        run: |
+          find . -type f \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 -i python -c "import yaml ; yaml.safe_load(open('{}'))" || exit 1


### PR DESCRIPTION
- Should be only rearrangements to match and non-semantic changes.

- Only questionable action I can notice is `mne` switches from pip to
  conda.  @eglerean