### PR TITLE
fgci-centos7-generic/anaconda: Adding nbval to generic build

### DIFF
--- a/configs/fgci-centos7-dev/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-dev/anaconda/build_config.yaml
@@ -73,7 +73,6 @@ collections:
       - pymanopt
       - python-igraph
       - roboschool
-
     conda_packages:
       - anaconda
       - anaconda-client

--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -102,6 +102,7 @@ collections:
       - jupyterlab-git
       - matlab-kernel
       - nbscript
+      - nbval
       - nbzip
       - opencv-contrib-python
       - pymanopt


### PR DESCRIPTION
This PR adds nbval to generic build.