### PR TITLE
fgci-centos7-generic: Add openmpi@1.6.5 to the build

### DIFF
--- a/configs/fgci-centos7-generic/spack/build_config.yaml
+++ b/configs/fgci-centos7-generic/spack/build_config.yaml
@@ -113,6 +113,8 @@ packages:
       - '+metis'
   - name: 'openmpi'
     version: 3.1.4
+  - name: 'openmpi'
+    version: 1.6.5
   - name: 'magma'
     version: 2.5.3
     dependencies:


### PR DESCRIPTION
This PR adds openmpi@1.6.5 to the build.