### PR TITLE
intel-parallel-studio-nompi: Adding intel-parallel-studio~mpi to fgci-centos7-generic

### DIFF
--- a/configs/fgci-centos7-generic/spack/build_config.yaml
+++ b/configs/fgci-centos7-generic/spack/build_config.yaml
@@ -42,6 +42,8 @@ compilers:
     version: 'cluster.2019.3'
     licenses:
       - 'license.lic'
+    variants:
+      - '+mpi'
     dependencies:
       - '%gcc@9.2.0'
     flags:
@@ -56,6 +58,8 @@ compilers:
     version: 'cluster.2020.0'
     licenses:
       - 'license.lic'
+    variants:
+      - '+mpi'
     dependencies:
       - '%gcc@9.2.0'
     flags:
@@ -151,3 +155,13 @@ packages:
     variants:
       - '+piclibs'
       - '+nvptx'
+  - name: 'intel-parallel-studio'
+    version: 'cluster.2020.0'
+    variants:
+      - '~mpi'
+    licenses:
+      - 'license.lic'
+    target_architecture:
+      platform: linux
+      os: centos7
+      arch: x86_64

--- a/configs/fgci-centos7-generic/spack/modules.yaml
+++ b/configs/fgci-centos7-generic/spack/modules.yaml
@@ -83,3 +83,5 @@ modules:
       environment:
         set:
           SLURM_MPI_TYPE: 'pmi2'
+      suffixes:
+        '+mpi'           : 'intelmpi'


### PR DESCRIPTION
This PR adds a version of intel-parallel-studio with no Intel MPI (for use with OpenMPI) and adds suffix intelmpi for versions of intel-parallel-studio with Intel MPI.