### PR TITLE
fgci-centos7-generic: freesurfer@6.0.0

### DIFF
--- a/configs/fgci-centos7-generic/spack/build_config.yaml
+++ b/configs/fgci-centos7-generic/spack/build_config.yaml
@@ -85,6 +85,8 @@ packages:
     version: 1.19.0
   - name: 'cuda'
     version: 10.1.243
+  - name: 'freesurfer'
+    version: 6.0.0
   - name: 'go'
     version: 1.12.8
   - name: 'heaptrack'


### PR DESCRIPTION
This PR adds package freesurfer@6.0.0 to the generic build.