### PR TITLE
fgci-centos7-generic/anaconda/rapidsai: This PR adds new anaconda environments with rapidsai.

### DIFF
--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -2,6 +2,7 @@ installer_checksums:
   Miniconda3-latest-Linux-x86_64.sh: 'bfe34e1fa28d6d75a7ad05fd02fa5472275673d5f5621b77380898dee1be15d2'
   Miniconda3-4.7.12.1-Linux-x86_64.sh: 'bfe34e1fa28d6d75a7ad05fd02fa5472275673d5f5621b77380898dee1be15d2'
   Anaconda3-2019.10-Linux-x86_64.sh: '46d762284d252e51cd58a8ca6c8adc9da2eadc82c342927b2f66ed011d1d8b53'
+  Anaconda3-2020.02-Linux-x86_64.sh: '2b9f088b2022edb474915d9f69a803d6449d5fdb4c303041f60ac4aefcc208bb'
 environments:
   - name: miniconda
     version: '4.7.12.1'
@@ -52,6 +53,7 @@ environments:
     miniconda: False
     python_version: 3
     installer_version: '2019.10'
+    freeze: True
     condarc:
       channels:
         - defaults
@@ -69,6 +71,7 @@ environments:
     miniconda: False
     python_version: 3
     installer_version: '2019.10'
+    freeze: True
     condarc:
       channels:
         - defaults

--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -131,7 +131,7 @@ collections:
   tensorflow-v2:
     conda_packages:
       - tensorboard
-      - tensorflow=2.0.0
+      - tensorflow=2.1.0
       - tensorflow-base
       - tensorflow-estimator
       - tensorflow-gpu

--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -84,6 +84,42 @@ environments:
     collections:
       - tensorflow-v2
       - triton-generic
+  - name: anaconda
+    version: '2020-03-tf1'
+    miniconda: False
+    python_version: 3
+    installer_version: '2020.02'
+    condarc:
+      channels:
+        - defaults
+        - pytorch
+        - gurobi
+        - IBMDecisionOptimization
+        - anaconda
+        - mosek
+        - rapidsai
+        - conda-forge
+    collections:
+      - tensorflow-v1
+      - triton-generic
+  - name: anaconda
+    version: '2020-03-tf2'
+    miniconda: False
+    python_version: 3
+    installer_version: '2020.02'
+    condarc:
+      channels:
+        - defaults
+        - pytorch
+        - gurobi
+        - IBMDecisionOptimization
+        - anaconda
+        - mosek
+        - rapidsai
+        - conda-forge
+    collections:
+      - tensorflow-v2
+      - triton-generic
 collections:
   tensorflow-v1:
     conda_packages:
@@ -144,6 +180,8 @@ collections:
       - cuda100
       - cudatoolkit
       - cudnn
+      - cupy
+      - cusignal
       - cython
       - dill
       - distributed

--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -226,7 +226,7 @@ collections:
       - more-itertools
       - mosek
       - mpi4py
-      - mpich2
+      - mpich
       - navigator-updater
       - nbconvert
       - nbdime


### PR DESCRIPTION
This PR:
  - Freezes anaconda/2020-02-tf2*-environments.
  - Adds new anaconda/2020-03-tf*-environments with rapidsai.
  - Included environments include cupy and cusignal.
  - tensorflow-v2 collection now installs tensorflow 2.1.0.
  - Old mpich2-package was replaced by mpich, as the other one is old and deprecated.