### PR TITLE
fgci-centos7-generic: Adding freesurfer@7.1.0

### DIFF
--- a/configs/fgci-centos7-generic/spack/build_config.yaml
+++ b/configs/fgci-centos7-generic/spack/build_config.yaml
@@ -89,6 +89,10 @@ packages:
     version: 6.0.0
     dependencies:
       - '^mesa+opengl+osmesa~llvm'
+  - name: 'freesurfer'
+    version: 7.1.0
+    dependencies:
+      - '^mesa+opengl+osmesa~llvm'
   - name: 'go'
     version: 1.12.8
   - name: 'heaptrack'


### PR DESCRIPTION
This PR adds freesurfer@7.1.0 to the build.